### PR TITLE
Fix typos in README, add python/pip requirements file and solve MatplotlibDeprecationWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Get the overview of security incidents reported by modsecurity module from modse
 
 
 # Description
-modsecurity parser is a python program to read <a href="https://www.modsecurity.org/">modsecurity.org</a> modsec_audit.log , tranform read events into more human and machine readable formats (xlsx/json) and make basic charts.
+modsecurity parser is a python program to read <a href="https://www.modsecurity.org/">modsecurity.org</a> modsec_audit.log, transform read events into more human and machine readable formats (xlsx/json) and make basic charts.
 
 
 <p>
@@ -67,7 +67,7 @@ Filters INCLUDE and EXCLUDE are available for IP source addresses.
 <p>
 --exclude option ( e.g. "--exclude 192.168.0.1 10.0.0.1") just skips events with given IP source addresses
 <p>
---include (e.g. "--include 10.0.5.6") take precedense over EXLUDE. INCLUDE process only events with given IP source addresses.
+--include (e.g. "--include 10.0.5.6") take precedence over EXCLUDE. INCLUDE process only events with given IP source addresses.
 <p>
 --jsononeperline  - option recommended for big number of events where e.g. produced JSON is supposed to be read by other SIEM tool. Uses the very same format as modsecurity software when type of logging is set to "JSON". 
 
@@ -84,10 +84,10 @@ Processing Modsecurity log in JSON format:
 
 
 # Limitations:
-<li>The biggest tested modsec_audit.log was 1GB size with around 70000 records. It took more or less 5 minutes on 8years old workstation and memory usage temporarily raised to 2GB of RAM.</li>
+<li>The biggest tested modsec_audit.log was 1GB size with around 70000 records. It took more or less 5 minutes on an 8 years old workstation and memory usage temporarily raised to 2GB of RAM.</li>
 <li>modsec_audit.log were taken from Apache web servers with locale set to en-US. Software can except some errors if datatime format is different in the audited log. Adjust LOG_TIMESTAMP_FORMAT and LOG_TIMESTAMP_FORMAT_SHORT accordingly</li>
 <li>To process more than 90000 events just adjust MAXEVENTS</li>
-<li>Tested with modsec_audit.log from version 2.8/2.9/3.0. Anyway Modsecurity3 for some cases produces empty sectionH and not all information is available to be properly presented in all graphs</li>
+<li>Tested with modsec_audit.log from version 2.8/2.9/3.0. Anyway Modsecurity3 for some cases produces empty H section and not all information is available to be properly presented in all graphs</li>
 
 # run via Docker
 

--- a/modsecurity-parser.py
+++ b/modsecurity-parser.py
@@ -451,7 +451,7 @@ def modsecViewGraphs(modsecDict):
 
     ''' Bar chart "TOP 10 Attacks intercepted" '''
     plt.subplot(ax31)
-    patches, texts, autotexts = plt.pie(intercepted_cnt_top10.values(), autopct='%1.1f%%', shadow=True, startangle=90, radius=1.0)
+    patches, texts, autotexts = plt.pie(intercepted_cnt_top10.values(), autopct='%1.1f%%', shadow=True, startangle=90, radius=1.0, normalize=False)
     [_.set_fontsize(7) for _ in texts]
     plt.title('TOP 10 Attacks intercepted', bbox={'facecolor': '0.8', 'pad': 5})
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+pillow
+pandas
+openpyxl


### PR DESCRIPTION
Fix a few typos and add a requirements file to install python libs using pip:
```bash
pip install -r requirements.txt
``` 
Also, solve MatplotlibDeprecationWarning when using matplotlib 3.3.1